### PR TITLE
Values will not save when selecting groups for CMS Restrictions

### DIFF
--- a/src/app/locale/it_IT/SchumacherFM_CmsRestriction.csv
+++ b/src/app/locale/it_IT/SchumacherFM_CmsRestriction.csv
@@ -1,0 +1,8 @@
+"CMS Restrictions","Limitazioni CMS"
+"URL Page Access denied","URL pagina di accesso negato"
+"If a customer is logged in and wants to access a restricted page he/she will be redirected to that page.","Se un utente dopo l'accesso cerca di vedere una pagina riservata, verrà inviato a questa pagina"
+"Restrict to customer groups or individual customers","Limita ad alcuni specifici gruppi o utenti"
+"Allow Customer Groups","Consenti gruppi di utenti"
+"Allow Customer IDs","Consenti alcuni ID utente"
+"Comma separated list with numbers.","Lista di numeri separati da virgole"
+"CMS Restriction","Limitazione CMS"


### PR DESCRIPTION
When selecting customer groups under CMS/Pages/CMS Restrictions it will let me select all of the ones in the list, but when I hit 'Save Page/Save and Continue Edit' only the first 33 selections will remain selected.
It appears that there is a character limit in the cms_page/allow_customer_groups column that this is running into.
I have attempted to manipulate this column in the database to resolve the issue and have been unsuccessful.

Attached is a SQL dump of the customer_group table for the merchant that this is affecting.

[customer_group.sql.txt](https://github.com/SchumacherFM/Magento-CmsRestriction/files/147081/customer_group.sql.txt)
