### PR TITLE
Large group id fix

### DIFF
--- a/src/app/code/community/SchumacherFM/CmsRestriction/Block/Adminhtml/Cms/Page/Edit/Tab/Cmsrestriction.php
+++ b/src/app/code/community/SchumacherFM/CmsRestriction/Block/Adminhtml/Cms/Page/Edit/Tab/Cmsrestriction.php
@@ -46,6 +46,7 @@ class SchumacherFM_CmsRestriction_Block_Adminhtml_Cms_Page_Edit_Tab_CmsRestricti
         $form = new Varien_Data_Form();
         $this->setForm($form);
         $registry = $this->_getCurrentPageInstance();
+        $allowedCustomerGroups = (strlen($registry->getAllowCustomerGroups()) > 0) ? explode(',', $registry->getAllowCustomerGroups()) : array();
 
         $fieldSet = $form->addFieldset('main_fieldset',
             array(
@@ -60,7 +61,7 @@ class SchumacherFM_CmsRestriction_Block_Adminhtml_Cms_Page_Edit_Tab_CmsRestricti
                 'label'    => Mage::helper('schumacherfm_cmsrestriction')->__('Allow Customer Groups'),
                 'title'    => Mage::helper('schumacherfm_cmsrestriction')->__('Allow Customer Groups'),
                 'required' => FALSE,
-                'value'    => Mage::helper('schumacherfm_cmsrestriction')->getIntByExpoSum($registry->getAllowCustomerGroups()),
+                'value'    => $allowedCustomerGroups,
                 'values'   => Mage::getModel('schumacherfm_cmsrestriction/option_groups')->toOptionArray()
             ));
 

--- a/src/app/code/community/SchumacherFM/CmsRestriction/Helper/Data.php
+++ b/src/app/code/community/SchumacherFM/CmsRestriction/Helper/Data.php
@@ -51,8 +51,16 @@ class SchumacherFM_CmsRestriction_Helper_Data extends Mage_Core_Helper_Abstract
     public function isPageRestricted(Mage_Cms_Model_Page $page)
     {
         $allowCustomerIds    = $page->getAllowCustomerIds();
-        $allowCustomerGroups = (int)$page->getAllowCustomerGroups();
-        return ($allowCustomerGroups > 0 || !empty($allowCustomerIds));
+        $allowCustomerGroups = $page->getAllowCustomerGroups();
+
+        if (strlen($allowCustomerGroups) > 0) {
+            $allowCustomerGroups = explode(',', $allowCustomerGroups);
+        }
+        else {
+            $allowCustomerGroups = null;
+        }
+
+        return (is_array($allowCustomerGroups) || !empty($allowCustomerIds));
     }
 
     /**
@@ -66,7 +74,10 @@ class SchumacherFM_CmsRestriction_Helper_Data extends Mage_Core_Helper_Abstract
         $customer        = Mage::helper('customer')->getCustomer();
         $pageCustomerIds = array_flip(explode(',', $page->getAllowCustomerIds()));
 
-        $isValidGroup      = ((pow(2, $customer->getGroupId()) & $page->getAllowCustomerGroups()) > 0);
+        $allowedCustomerGroups = $page->getAllowCustomerGroups();
+        $allowedCustomerGroups = explode(',', $allowedCustomerGroups);
+        $isValidGroup = (in_array($customer->getGroupId(), $allowedCustomerGroups)) ? TRUE : FALSE;
+
         $isValidCustomerId = isset($pageCustomerIds[$customer->getEntityId()]);
 
         return ($isValidGroup || $isValidCustomerId);

--- a/src/app/code/community/SchumacherFM/CmsRestriction/Model/Observer.php
+++ b/src/app/code/community/SchumacherFM/CmsRestriction/Model/Observer.php
@@ -48,7 +48,9 @@ class SchumacherFM_CmsRestriction_Model_Observer
         $allowedCustomerGroups = (array)$page->getAllowCustomerGroups();
         $allowedCustomerIds    = preg_replace('~[^0-9,]+~', '', $page->getAllowCustomerIds());
 
-        $page->setAllowCustomerGroups(Mage::helper('schumacherfm_cmsrestriction')->getExpoSum($allowedCustomerGroups));
+        if (!is_array($allowedCustomerGroups)) { $allowedCustomerGroups = array($allowedCustomerGroups); }
+
+        $page->setAllowCustomerGroups(implode(',', $allowedCustomerGroups));
         $page->setAllowCustomerIds($allowedCustomerIds);
     }
 

--- a/src/app/code/community/SchumacherFM/CmsRestriction/sql/schumacherfm_cmsrestriction_setup/install-0.0.1.php
+++ b/src/app/code/community/SchumacherFM/CmsRestriction/sql/schumacherfm_cmsrestriction_setup/install-0.0.1.php
@@ -17,9 +17,8 @@ $tables = array(
     $installer->getTable('cms/page')  => array(
         'columns' => array(
             'allow_customer_groups' => array(
-                'type'    => Varien_Db_Ddl_Table::TYPE_BIGINT,
-                'default' => '0',
-                'length'  => 25,
+                'type'    => Varien_Db_Ddl_Table::TYPE_TEXT,
+                'default' => '',
                 'comment' => 'Allowed Customer Groups'
             ),
             'allow_customer_ids'    => array(
@@ -32,9 +31,8 @@ $tables = array(
     $installer->getTable('cms_block') => array(
         'columns' => array(
             'allow_customer_groups' => array(
-                'type'    => Varien_Db_Ddl_Table::TYPE_BIGINT,
-                'default' => '0',
-                'length'  => 25,
+                'type'    => Varien_Db_Ddl_Table::TYPE_TEXT,
+                'default' => '',
                 'comment' => 'Allowed Customer Groups'
             ),
             'allow_customer_ids'    => array(


### PR DESCRIPTION
You're using a BIGINT here to store the acceptable group ids which works... until you hit the maximum integer size that a database can store. This causes either a number that's too large to store or wild inconsistencies when saving groups with group ids that are big. For instance we have about a dozen groups, some of which (for whatever reason) have ids > 100. Theoretically, this is a problem at quite a low number. This fix just makes your group field a comma separated list that gets imploded() and exploded() as needed which is much easier to manage. Not for nothing, but it does save on calculating these groups as being valid with a simple comparison. You could replace the BIGINT field with a text field but then you might run into issues where the integer values are simply too big for PHP to handle in a 64-bit architecture, which I'm sure you don't want :)

Otherwise an excellent extension. Thank you! Hope this helps